### PR TITLE
Add and remove callbacks on file descriptors (sockets and others) events.

### DIFF
--- a/examples/socket.lua
+++ b/examples/socket.lua
@@ -38,6 +38,7 @@ local function sk_client_cb(fd)
     browser:add(string.format("fd%d closed by peer", fd))
     client:close()
     fl.remove_fd(fd)
+    clients[fd] = nil
   end
 end
 

--- a/examples/socket.lua
+++ b/examples/socket.lua
@@ -1,0 +1,121 @@
+#!/usr/bin/env lua
+
+local fl = require"fltk4lua"
+local socket = require"socket"
+
+
+local window = fl.Window(400, 300)
+  local label = fl.Box(10, 10, 380, 40, "This program listens on port 20000 and display the lines it receives below")
+  label.align = fl.ALIGN_TOP + fl.ALIGN_CENTER + fl.ALIGN_WRAP + fl.ALIGN_INSIDE
+
+  local browser = fl.Browser(10, 60, 380, 190)
+
+  local msgb = fl.Button(10, 260, 160, 30, "Broadcast message")
+
+  local connectb = fl.Button(180, 260, 100, 30, "Connect")
+
+  local quitb = fl.Button(290, 260, 90, 30, "Quit")
+  function quitb.callback()
+    window:hide()
+  end
+window:end_group()
+window:show(arg)
+
+-------------------------------------------------
+-- Network callbacks and server initialization --
+-------------------------------------------------
+
+local clients = {}
+
+-- When we receive data from client
+local function sk_client_cb(fd)
+  local client = clients[fd]
+  local data, status, rdata = client:receive"*l"
+  if data or rdata ~= "" then
+    browser:add(string.format("fd%d: %s", fd, data or rdata))
+  end
+  if status == "closed" then
+    browser:add(string.format("fd%d closed by peer", fd))
+    client:close()
+    fl.remove_fd(fd)
+  end
+end
+
+-- Used when we can WRITE to a new client to know if the connection succeeded
+local function sk_connect_cb(fd)
+  local client = clients[fd]
+  local ip, port = client:getpeername()
+  if ip then
+    browser:add(string.format("fd%d opened to server %s:%d", fd, ip, port))
+    client:send"hello sever\n"
+    fl.add_fd(fd, sk_client_cb)
+  else
+    fl.message"Connection failed"
+    clients[fd] = nil
+  end
+  fl.remove_fd(fd, fl.WRITE)
+end
+
+function connectb.callback()
+  local client
+  local r = fl.input"Enter an client IP and port separated by a space:"
+  if r then
+    local ip, port = r:match"^([^ ]+) ([1-9][0-9]*)$"
+    if ip and port then
+      if ip:match"^[0-9a-bA-B:]+$" then -- ipv6
+        client = socket.tcp6()
+      elseif ip:match"^[0-9.]+$" then --ipv4
+        client = socket.tcp()
+      else
+        fl.message"Unknown IP scheme"
+        return
+      end
+      client:settimeout(0)
+      client:connect(ip, port)
+      clients[client:getfd()] = client
+      fl.add_fd(client:getfd(), sk_connect_cb, fl.WRITE)
+    else
+      fl.message"Invalid IP:port"
+      return
+    end
+  end
+end
+
+function msgb.callback()
+  local msg = fl.input"Enter a message to send it to all clients:"
+  if msg then
+    for _, s in pairs(clients) do
+      s:send(msg .. "\n")
+    end
+  end
+  browser:add("broadcasted: "..msg)
+end
+
+local server = socket.bind("*", 20000)
+if not server then
+  error"Cannot listen on port 20000"
+end
+
+fl.add_fd(server:getfd(), function ()
+  local client = server:accept()
+  client:settimeout(0)
+  local fd, ip, port = client:getfd(), client:getpeername()
+  browser:add(string.format("fd%d opened by client at %s:%d", fd, ip, port))
+  clients[fd] = client
+  fl.add_fd(fd, sk_client_cb)
+  client:send"hello client\n"
+end)
+
+-------------------------
+-- Run the application --
+-------------------------
+
+fl.run()
+
+-- Close the sockets, even if not needed
+for _, s in pairs(clients) do
+  fl.remove_fd(s:getfd())
+  s:send"good bye\n"
+  s:close()
+end
+

--- a/src/f4l_enums.cxx
+++ b/src/f4l_enums.cxx
@@ -565,6 +565,21 @@ MOON_LOCAL void f4l_push_font( lua_State* L, Fl_Font f ) {
   }
 }
 
+#define FD_WHEN_LIST( _ ) \
+  _( "READ", FL_READ ) \
+  _( "WRITE", FL_WRITE ) \
+  _( "EXCEPT", FL_EXCEPT )
+
+#define MOON_FLAG_NAME "fltk4lua.Fd_When"
+#define MOON_FLAG_TYPE int
+#define MOON_FLAG_SUFFIX fd_when
+#define MOON_FLAG_USECACHE
+#define MOON_FLAG_NORELOPS
+#include "moon_flag.h"
+
+MOON_LOCAL int f4l_check_fd_when( lua_State* L, int idx ) {
+  return moon_flag_get_fd_when( L, idx );
+}
 
 #define COLOR_LIST( _ ) \
   _( "FOREGROUND_COLOR", FL_FOREGROUND_COLOR ) \
@@ -771,6 +786,7 @@ MOON_LOCAL void f4l_enums_setup( lua_State* L ) {
   moon_flag_def_mode( L );
 #endif
   moon_flag_def_when( L );
+  moon_flag_def_fd_when( L );
   moon_flag_def_align( L );
   moon_flag_def_color( L );
 #define GEN_UDATA( _a, _b ) \
@@ -792,6 +808,10 @@ MOON_LOCAL void f4l_enums_setup( lua_State* L ) {
 #define GEN_UDATA( _a, _b ) \
   (moon_flag_new_when( L, _b ), lua_setfield( L, -2, _a ));
   WHEN_LIST( GEN_UDATA )
+#undef GEN_UDATA
+#define GEN_UDATA( _a, _b ) \
+  (moon_flag_new_fd_when( L, _b ), lua_setfield( L, -2, _a ));
+  FD_WHEN_LIST( GEN_UDATA )
 #undef GEN_UDATA
 #define GEN_UDATA( _a, _b ) \
   (moon_flag_new_align( L, _b ), lua_setfield( L, -2, _a ));

--- a/src/f4l_enums.hxx
+++ b/src/f4l_enums.hxx
@@ -54,6 +54,8 @@ MOON_LOCAL void f4l_push_mode( lua_State* L, Fl_Mode m );
 MOON_LOCAL Fl_When f4l_check_when( lua_State* L, int idx );
 MOON_LOCAL void f4l_push_when( lua_State* L, Fl_When w );
 
+MOON_LOCAL int f4l_check_fd_when( lua_State* L, int idx );
+
 MOON_LOCAL Fl_Cursor f4l_check_cursor( lua_State* L, int idx );
 MOON_LOCAL void f4l_push_cursor( lua_State* L, Fl_Cursor c );
 

--- a/src/fltk4lua.cxx
+++ b/src/fltk4lua.cxx
@@ -220,17 +220,15 @@ MOON_LOCAL void f4l_set_active_thread( lua_State* L ) {
 
 static void get_fd_cache( lua_State * L ) {
   static int xyz = 0;
-  moon_getcache( L, LUA_REGISTRYINDEX );
   lua_pushlightuserdata( L, static_cast< void* >( &xyz ) );
-  lua_rawget( L, -2 );
+  lua_rawget( L, LUA_REGISTRYINDEX );
   if( lua_isnil( L, -1 )) {
     lua_pop( L, 1 );
     lua_newtable( L );
     lua_pushlightuserdata( L, static_cast< void* >( &xyz ) );
     lua_pushvalue( L, -2 );
-    lua_rawset( L, -4 );
+    lua_rawset( L, LUA_REGISTRYINDEX );
   }
-  lua_remove( L, -2 );
 }
 
 static void f4l_fd_cb( FL_SOCKET fd, void* ud, int when ) {


### PR DESCRIPTION
This codes adds both method `fl.add_fd()` and `fl.remove_fd()` that tell `fl.wait()` to monitor file descriptors. It is useful for monitoring sockets, and any file descriptor on POSIX systems.

An program `socket.lua` was added to the examples to demonstrate how to use those new functions.

I successfully tested this example code on Debian Jessie Linux, Mac OSX Mountain Lion and Windows 7.
