### PR TITLE
Added read-only window.xid accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Comments and feedback are always welcome.
 `fltk4lua` is *copyrighted free software* distributed under the MIT
 license (the same license as Lua 5.1). The full license text follows:
 
-    fltk4lua (c) 2015, 2016 Philipp Janda
+    fltk4lua (c) 2015-2018 Philipp Janda and contributors
 
     Permission is hereby granted, free of charge, to any person obtaining
     a copy of this software and associated documentation files (the
@@ -59,4 +59,10 @@ license (the same license as Lua 5.1). The full license text follows:
     CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+###                           Contributors                         ###
+
+ - [Philipp Janda](https://github.com/siffiejoe)
+ - [Jérémy Farnaud](https://github.com/remjey)
+ - [Chris White](https://github.com/cxw42)
 

--- a/src/f4l_window.cxx
+++ b/src/f4l_window.cxx
@@ -6,6 +6,8 @@
 #include <cstring>
 #include <climits>
 
+#include <Fl/x.H>
+  // for fl_xid
 
 namespace {
 
@@ -201,6 +203,13 @@ MOON_LOCAL int f4l_window_index_( lua_State* L, Fl_Window* w,
                                   char const* key, size_t n ) {
   using namespace std;
   switch( n ) {
+    case 3:
+      if( F4L_MEMCMP( key, "xid", 3 ) == 0 ) {
+        Window x = fl_xid( w );
+        lua_pushlightuserdata( L, x );
+        return 1;
+      }
+      break;
     case 5:
       if( F4L_MEMCMP( key, "label", 5 ) == 0 ) {
         char const* label = w->label();


### PR DESCRIPTION
Disclaimer: First-time submitter, and a relative newbie at FLTK. :)

I am using fltk4lua in [a personal project](https://github.com/cxw42/srlua) on mingw.  I needed a window's HWND so that I could set the window icon.  Per [the FLTK docs](http://www.fltk.org/doc-1.1/osissues.html), `fl_xid` is the function to use.  I therefore added a Lua `window.xid` accessor to call `fl_xid`.  Sound reasonable?  I do note that I have not tested it on X or other platforms.  At present, cygwin and mingw are all I have access to.  Thanks for considering this PR!

The other commit is to add a contributors list to the README.