### PR TITLE
Add static compile option, useful for embedding in binaries, just declare and call luaopen_fltk4lua() via Lua.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@
 DLL_INSTALL_DIR = /usr/lib/lua/5.2
 LUA_INCDIR = /usr/include/lua5.2
 FLTK_CONFIG = fltk-config
-
+AR = ar
+RANLIB = ranlib
 CC = gcc
 CFLAGS = -Wall -Wextra -fpic -Os
 MYCFLAGS = ${CFLAGS} -I${LUA_INCDIR} -Imoon -Icompat-5.3/c-api \
@@ -14,6 +15,7 @@ MYCFLAGS = ${CFLAGS} -I${LUA_INCDIR} -Imoon -Icompat-5.3/c-api \
 MYLDFLAGS = `${FLTK_CONFIG} --use-images --ldflags` -lstdc++
 LIBFLAG = -shared
 LIB_EXTENSION = so
+STATICLIB_EXTENSION = a
 
 DLLBASENAME = fltk4lua
 SOURCES = \
@@ -59,6 +61,10 @@ OBJECTS = ${SOURCES:%.cxx=%.o} moon/moon.o compat-5.3/c-api/compat-5.3.o
 
 all: ${DLLBASENAME}.${LIB_EXTENSION}
 
+static: ${OBJECTS}
+	${AR} rc ${DLLBASENAME}.${STATICLIB_EXTENSION} ${OBJECTS}
+	${RANLIB} ${DLLBASENAME}.${STATICLIB_EXTENSION}
+
 ${DLLBASENAME}.${LIB_EXTENSION}: ${OBJECTS}
 	${CC} ${MYCFLAGS} ${LIBFLAG} -o $@ ${OBJECTS} ${MYLDFLAGS}
 
@@ -80,7 +86,7 @@ depend:
 	done
 
 clean:
-	rm -f ${DLLBASENAME}.${LIB_EXTENSION} ${OBJECTS} dependencies.txt
+	rm -f ${DLLBASENAME}.${LIB_EXTENSION} ${DLLBASENAME}.${STATICLIB_EXTENSION} ${OBJECTS} dependencies.txt
 
 
 # dependencies


### PR DESCRIPTION
I'm hoping these few lines in the Makefile will be alright, having it compile as a static library is very useful for some things, where you want a self-contained statically linked executable, like I do for my project Volition.

Thanks!